### PR TITLE
Add pracuj.pl dynamic theme fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17774,6 +17774,15 @@ svg
 
 ================================
 
+pracuj.pl
+
+CSS
+[alt="background"] {
+    display: none !important;
+}
+
+================================
+
 pressgazette.co.uk
 
 INVERT


### PR DESCRIPTION
This Polish job board uses a white image with blurry, barely visible dots as background. They look ok in light mode, but not so much using Dark Reader because it was still white. I opted to use a plain background as it looked better than the inverted image.

Before: White background with barely visible pattern in dark mode
![image](https://github.com/gorgonzola5000/darkreader/assets/124526284/1be62876-c253-4b79-9d83-df4c84557c23)

After: Dark plain background using dark mode. Vanilla website in light mode.
![image](https://github.com/gorgonzola5000/darkreader/assets/124526284/72c90a57-6f0b-4fdc-968d-9bd5f987a178)
